### PR TITLE
Merijn tried to add MVA scores for signal cateogry

### DIFF
--- a/HTTSMCPDecays18/bin/MorphingSMCPDecays18.cpp
+++ b/HTTSMCPDecays18/bin/MorphingSMCPDecays18.cpp
@@ -453,6 +453,8 @@ int main(int argc, char** argv) {
         {9, "tt_2016_higgs_Pi_A1_Mixed"},
         {10, "tt_2016_higgs_Pi_0A1_Mixed"},
         {11, "tt_2016_higgs_A1_0A1"},
+	{100, "tt_2016_higgs"}, //Merijn 2006	
+
         //{11, "tt_2016_higgs_other"},
       };
       cats["mt_2016"] = {
@@ -462,6 +464,8 @@ int main(int argc, char** argv) {
 	{4, "mt_mupi_sig_2016"},
 	{5, "mt_mua1_sig_2016"},
 	{6, "mt_mu0a1_sig_2016"},
+        {100, "mt_sig_2016"}, //Merijn 2006	
+	
       };
     }  
     if( era.find("2017") != std::string::npos ||  era.find("all") != std::string::npos) {
@@ -477,6 +481,7 @@ int main(int argc, char** argv) {
         {9, "tt_2017_higgs_Pi_A1_Mixed"},
         {10, "tt_2017_higgs_Pi_0A1_Mixed"},
         {11, "tt_2017_higgs_A1_0A1"},
+        {100, "tt_2017_higgs"}, //Merijn 2006		
         //{11, "tt_2017_higgs_other"},
       };
       cats["mt_2017"] = {
@@ -486,6 +491,7 @@ int main(int argc, char** argv) {
         {4, "mt_mupi_sig_2017"},
         {5, "mt_mua1_sig_2017"},
         {6, "mt_mu0a1_sig_2017"},
+        {100, "mt_sig_2017"}, //Merijn 2006	
       };
     }
     if( era.find("2018") != std::string::npos ||  era.find("all") != std::string::npos) {
@@ -500,7 +506,8 @@ int main(int argc, char** argv) {
         {8, "tt_2018_higgs_Pi_Pi"},
         {9, "tt_2018_higgs_Pi_A1_Mixed"}, 
         {10, "tt_2018_higgs_Pi_0A1_Mixed"}, 
-        {11, "tt_2018_higgs_A1_0A1"},
+        {11, "tt_2018_higgs_A1_0A1"},	
+        {100, "tt_2018_higgs"}, //Merijn 2006	
         //{11, "tt_2018_higgs_other"},
       };
       cats["mt_2018"] = {
@@ -510,6 +517,7 @@ int main(int argc, char** argv) {
         {4, "mt_mupi_sig_2018"},
         {5, "mt_mua1_sig_2018"},
         {6, "mt_mu0a1_sig_2018"},
+        {100, "mt_sig_2018"}, //Merijn 2006	
       };
     }
     
@@ -1367,8 +1375,18 @@ int main(int argc, char** argv) {
       });
     writer.WriteCards("htt_stage2", cb.cp().attr({"stage2"},"cat"));
 
+
+         writer.WriteCards("htt_bkg_tt_signalmva_2018", cb.cp().channel({"tt_2018"}).bin_id({1,2,100})); //merijn 2006
+     writer.WriteCards("htt_bkg_tt_signalmva_2017", cb.cp().channel({"tt_2017"}).bin_id({1,2,100})); //merijn 2006
+      writer.WriteCards("htt_bkg_tt_signalmva_2016", cb.cp().channel({"t_2016"}).bin_id({1,2,100})); //merijn 2006
+
+      writer.WriteCards("htt_bkg_mt_signalmva_2018", cb.cp().channel({"mt_2018"}).bin_id({1,2,100})); //merijn 2006
+      writer.WriteCards("htt_bkg_mt_signalmva_2017", cb.cp().channel({"mt_2017"}).bin_id({1,2,100})); //merijn 2006
+      writer.WriteCards("htt_bkg_mt_signalmva_2016", cb.cp().channel({"mt_2016"}).bin_id({1,2,100})); //merijn 2006
+
     cb.PrintAll();
     cout << " done\n";
     
     
 }
+

--- a/HTTSMCPDecays18/scripts/plotting.py
+++ b/HTTSMCPDecays18/scripts/plotting.py
@@ -11,7 +11,7 @@ import scipy
 import uproot
 from tqdm.auto import tqdm
 mpl.use('pdf')
-plt.style.use('cms')
+#plt.style.use('cms')
 
 def create_df(
     datacard, directory, channel, processes, ch_kw={}, variations=[],
@@ -600,6 +600,7 @@ nbins_kw = {
         9: [[0., 0.7, 0.8, 0.9, 1.], 4, r'$\pi a_{1}^{3\mathrm{pr}}$', "pi-a1"], # pi-a1
         10: [[0., 0.7, 0.8, 0.9, 1.], 4, r'$\pi a_{1}^{1\mathrm{pr}}$', "pi-0a1"], # pi-0a1
         11: [[0., 0.7, 0.8, 1.], 4, r'$a_{1}^{3\mathrm{pr}} a_{1}^{1\mathrm{pr}}$', "a1-0a1"], # a1-0a1
+        100: [[None], 1, "embed", "embed"], # Higgs MVA
     },
     "mt": {
         1: [[None], 1, "embed", "embed"], # embed
@@ -608,6 +609,7 @@ nbins_kw = {
         4: [[0.0, 0.45, 0.6, 0.7, 0.8, 0.9, 1.0], 8, r'$\mu\pi$', "mu-pi"], # mu-pi
         5: [[0.0, 0.45, 0.6, 0.7, 0.8, 0.9, 1.0], 4, r'$\mu a_{1}^{3\mathrm{pr}}$', "mu-a1"], # mu-a1
         6: [[0.0, 0.45, 0.6, 0.8, 1.0], 4, r'$\mu a_{1}^{1\mathrm{pr}}$', "mu-0a1"], # mu-0a1
+        100: [[None], 1, "embed", "embed"], # Higgs MVA
     },}
 
 nllscan_kw = {

--- a/HTTSMCPDecays18/scripts/run_draw1d_cpdecays.py
+++ b/HTTSMCPDecays18/scripts/run_draw1d_cpdecays.py
@@ -127,9 +127,9 @@ def draw1d_cpdecays(
     # 1-2: backgrounds, 3+: higgs categories
     # correspond to CH bins defined in Morphing scripts
     if channel == "tt":
-        bins_to_plot = list(range(1, 12))
+        bins_to_plot = list(range(100,101)) #was 12
     elif channel == "mt":
-        bins_to_plot = list(range(1,7))
+        bins_to_plot = list(range(100,101))#was 7
     for bin_number in bins_to_plot:
 
         category = nbins_kw[channel][bin_number][3]
@@ -147,7 +147,7 @@ def draw1d_cpdecays(
                 plot_var = "BDT_score"
             elif channel == "mt":
                 plot_var = "NN_score"
-            partial_blind = False
+            partial_blind = True
             unrolled = False
             norm_bins = True
         else:


### PR DESCRIPTION
pupose here is to add MVA scores for the signal categories, such that we can review these prefit and postfit.
We need to update for the AN.

I maanged to extract the result, some changes are needed in plotting.py which I'm not managing right now.
Currently it can plot the Higgs category, but it will call it _embed in the pdf name, and althought I tried to blind the data this is not working yet, so please treat carefully.
to do list:
1) make sure the wsitch for blinding data works
2) make sure name Higgs mva or something gets properly appended

we could consider to pick a different index from 100, this was pretty random to avoid overlaps with existing.

Best,
Merijn